### PR TITLE
AuthControl Commands

### DIFF
--- a/authcontrol.cfg
+++ b/authcontrol.cfg
@@ -91,7 +91,7 @@ cmd_authstate = [
 				if (= $res -1) [
 					db_error $auth_db
 				] [
-					pm $arg1 (format "^f6[ AUTHCONTROL ] ^f0The authkey for ^f5%1 ^f0is now: %2" $arg2 (? ($arg3) "enabled" "^f3disabled"))
+					pm $arg1 (format "^f6[ AUTHCONTROL ] ^f0The authkey for ^f5%1 ^f0is now %2" $arg2 (? ($arg3) "enabled" "^f3disabled"))
 				]
 			] [
 				pm $arg1 "^f3[ ERROR ] ^f0You must choose -1, 0, or 1 to change state of this authkey!"
@@ -165,7 +165,7 @@ cmd_listauth = [
 
 //Register commands
 if (=s $auth_db "") [
-	echo "[ AUTHCONTROL ] Error:  You must use a MySQL or SQLite database for the authkeys to use AuthControl."
+	log_warn "[ AUTHCONTROL ] Commands disabled!  You must use a MySQL/MySQLi database in order to use this script!"
 ] [
 	registercommand "addauth" cmd_addauth 3 "www" "addauth [NAME] [PUBLIC KEY] [A or M] | Adds an authkey with the given information.  Requires an SQLite or MySQL database."
 	registercommand "authstate" cmd_authstate 3 "wi" "authstate [NAME] [-1|0|1] | Changes the state of an authkey.  -1 = delete, 0 = disable, 1 = enable.  NOTE: You must run ^f5#syncauth ^f0after using this command!"

--- a/authcontrol.cfg
+++ b/authcontrol.cfg
@@ -1,0 +1,174 @@
+//AuthControl for Remod by subbed74
+//Adds commands to allow the modification of authkeys in-game
+//IMPORTANT: Requires the authkeys to be stored in the sqlite database, or a MySQL database
+
+//Command aliases
+cmd_addauth = [
+	if (|| (=s $arg4 "m") (=s $arg4 "a")) [
+		//Query to add authkeys
+		db__uid = (db_get_dbuid $auth_db)
+
+		tempstring = (format "SELECT name, pubkey FROM %1 WHERE name='%2' OR pubkey='%3'" $auth_table $arg2 $arg3)
+		authquery = (db_query $tempstring $auth_db)
+
+		if (= $authquery -1) [
+			db_error $auth_db
+		] [
+			authrow = (db_getrow $authquery $auth_db)
+			db_finalize $authquery $auth_db
+
+			if (!=s $authrow "") [
+				pm $arg1 "^f3[ ERROR ] ^f0That key or username is already being used!"
+			] [
+				cases (db_get_engine $auth_db) "sqlite3" [
+					sqlite3_query $db__uid "BEGIN TRANSACTION"
+					sqlite3_pquery $db__uid "INSERT INTO `:0` (name, pubkey, rights, enabled) VALUES (':1', ':2', ':3', 1)" $auth_table $arg2 $arg3 $arg4
+					res = (sqlite3_query $db__uid "COMMIT")
+				] "mysql" [
+					res = (mysql_pquery $db__uid "INSERT INTO `:0` (name, pubkey, rights, enabled) VALUES (':1', ':2', ':3', 1)" $auth_table $arg2 $arg3 $arg4)
+				] [
+					res = -1
+				]
+
+				//Tell the player the key was added
+				if (=s $res -1) [
+					db_error $auth_db
+				] [
+					auth_load_from_db
+					pm $arg1 (format "^f6[ AUTHCONTROL ] ^f0A key was successfully added for ^f5%1 ^f0with ^f5%2 ^f0privileges!" $arg2 (? (=s $arg4 "a") "admin" "master"))
+				]
+			]
+		]
+	] [
+		pm $arg1 "^f3[ ERROR ] ^f0You must provide an ^"a^" or an ^"m^" for admin/master privileges!"
+	]
+]
+
+cmd_authstate = [
+	//Check if user exists
+	db__uid = (db_get_dbuid $auth_db)
+
+	tempstring = (format "SELECT rights FROM %1 WHERE name='%2'" $auth_table $arg2)
+	authquery = (db_query $tempstring $auth_db)
+	if (= $authquery -1) [
+		db_error $auth_db
+	] [
+		authrow = (db_getrow $authquery $auth_db)
+		db_finalize $authquery $auth_db
+
+		if (=s $authrow "") [
+			pm $arg1 (format "^f3[ ERROR ] ^f0No one has an authkey with the name ^f5%1" $arg2)
+		] [  //If user exists, validate the integer
+			cond (= $arg3 -1) [  //Delete the authkey
+				cases (db_get_engine $auth_db) "sqlite3" [
+					sqlite3_query $db__uid "BEGIN TRANSACTION"
+					sqlite3_pquery $db__uid "DELETE FROM `:0` WHERE name=':1'" $auth_table $arg2
+					res = (sqlite3_query $db__uid "COMMIT")
+				] "mysql" [
+					res = (mysql_pquery $db__uid "DELETE FROM `:0` WHERE name=':1'" $auth_table $arg2)
+				] [
+					res = -1
+				]
+
+				//Send a message to the user if successful then reload keys
+				if (= $res -1) [
+					db_error $auth_db
+				] [
+					pm $arg1 (format "^f6[ AUTHCONTROL ] ^f0The authkey for ^f5%1 ^f0was successfully deleted!" $arg2)
+				]
+			] (|| (= $arg3 1) (! $arg3)) [ //Enables/Disables the authkey
+				cases (db_get_engine $auth_db) "sqlite3" [
+					sqlite3_query $db__uid "BEGIN TRANSACTION"
+					sqlite3_pquery $db__uid "UPDATE `:0` SET enabled=:1 WHERE name=':2'" $auth_table $arg3 $arg2
+					res = (sqlite3_query $db__uid "COMMIT")
+				] "mysql" [
+					res = (mysql_pquery $db__uid "UPDATE `:0` SET enabled=:1 WHERE name=':2'" $auth_table $arg3 $arg2)
+				] [
+					res = -1
+				]
+
+				//Send a message to the user if successful then reload keys
+				if (= $res -1) [
+					db_error $auth_db
+				] [
+					pm $arg1 (format "^f6[ AUTHCONTROL ] ^f0The authkey for ^f5%1 ^f0is now: %2" $arg2 (? ($arg3) "enabled" "^f3disabled"))
+				]
+			] [
+				pm $arg1 "^f3[ ERROR ] ^f0You must choose -1, 0, or 1 to change state of this authkey!"
+			]
+		]
+	]
+]
+
+cmd_authpriv = [
+	//Check if user exists
+	db__uid = (db_get_dbuid $auth_db)
+
+	tempstring = (format "SELECT rights FROM %1 WHERE name='%2'" $auth_table $arg2)
+	authquery = (db_query $tempstring $auth_db)
+	if (= $authquery -1) [
+		db_error $auth_db
+	] [
+		authrow = (db_getrow $authquery $auth_db)
+		db_finalize $authquery $auth_db
+
+		if (=s $authrow "") [
+			pm $arg1 (format "^f3[ ERROR ] ^f0No one has an authkey with the name ^f5%1" $arg2)
+		] [ //Change the user's privileges
+			if (&& (!=s $arg3 "m") (!=s $arg3 "a")) [ //Validate the privilege
+				pm $arg1 "^f3[ ERROR ] ^f0You must specify ^"a^" or ^"m^" for the privilege!"
+			] [
+				cases (db_get_engine $auth_db) "sqlite3" [
+					sqlite3_query $db__uid "BEGIN TRANSACTION"
+					sqlite3_pquery $db__uid "UPDATE `:0` SET rights=':1' WHERE name=':2'" $auth_table $arg3 $arg2
+					res = (sqlite3_query $db__uid "COMMIT")
+				] "mysql" [
+					res = (mysql_pquery $db__uid "UPDATE `:0` SET rights=':1' WHERE name=':2'" $auth_table $arg3 $arg2)
+				] [
+					res = -1
+				]
+
+				if (= $res -1) [
+					db_error $auth_db
+				] [
+					pm $arg1 (format "^f6[ AUTHCONTROL ] ^f0Privileges for ^f5%1 ^f0set to %2" $arg2 (? (=s $arg3 "m") "master" "^f6admin"))
+					auth_load_from_db
+				]
+			]
+		]
+	]
+]
+
+cmd_listauth = [
+	// Get all the users
+	db__uid = (db_get_dbuid $auth_db)
+
+	tempstring = (format "SELECT name, rights FROM %1" $auth_table)
+	authquery = (db_query $tempstring $auth_db)
+
+	// Check for error, if no error store data in list
+	if (= $authquery -1) [
+		db_error $auth_db
+	] [
+		auth_list = ""
+
+		// Loop through the data and concat it to the list
+		while [ row = (db_getrow $authquery $auth_db); result (!=s $row "")] [
+			auth_list = (format "%1 %2%3" $auth_list (? (=s (at $row 1) "m") "^f0" "^f6") (at $row 0))
+		]
+		db_finalize $authquery $auth_db
+
+		// PM the list to the user
+		pm $arg1 (format "^f3[ AUTH ] ^f0Users: %1" $auth_list)
+	]
+]
+
+//Register commands
+if (=s $auth_db "") [
+	echo "[ AUTHCONTROL ] Error:  You must use a MySQL or SQLite database for the authkeys to use AuthControl."
+] [
+	registercommand "addauth" cmd_addauth 3 "www" "addauth [NAME] [PUBLIC KEY] [A or M] | Adds an authkey with the given information.  Requires an SQLite or MySQL database."
+	registercommand "authstate" cmd_authstate 3 "wi" "authstate [NAME] [-1|0|1] | Changes the state of an authkey.  -1 = delete, 0 = disable, 1 = enable.  NOTE: You must run ^f5#syncauth ^f0after using this command!"
+	registercommand "authpriv" cmd_authpriv 3 "ww" "authpriv [NAME] [a|m] | Changes the privileges for a user's authkey between master or admin."
+	registercommand "listauth" cmd_listauth 3 "" "listauth | Lists all users with an authkey.  Green names are masters, orange names are admins."
+]

--- a/authcontrol.cfg
+++ b/authcontrol.cfg
@@ -4,10 +4,9 @@
 
 //Command aliases
 cmd_addauth = [
-	if (|| (=s $arg4 "m") (=s $arg4 "a")) [
-		//Query to add authkeys
-		db__uid = (db_get_dbuid $auth_db)
+	auth_priv = (? (=s $arg4 "") "m" $arg4)
 
+	if (|| (=s $auth_priv "m") (=s $auth_priv "a")) [
 		tempstring = (format "SELECT name, pubkey FROM %1 WHERE name='%2' OR pubkey='%3'" $auth_table $arg2 $arg3)
 		authquery = (db_query $tempstring $auth_db)
 
@@ -20,34 +19,24 @@ cmd_addauth = [
 			if (!=s $authrow "") [
 				pm $arg1 "^f3[ ERROR ] ^f0That key or username is already being used!"
 			] [
-				cases (db_get_engine $auth_db) "sqlite3" [
-					sqlite3_query $db__uid "BEGIN TRANSACTION"
-					sqlite3_pquery $db__uid "INSERT INTO `:0` (name, pubkey, rights, enabled) VALUES (':1', ':2', ':3', 1)" $auth_table $arg2 $arg3 $arg4
-					res = (sqlite3_query $db__uid "COMMIT")
-				] "mysql" [
-					res = (mysql_pquery $db__uid "INSERT INTO `:0` (name, pubkey, rights, enabled) VALUES (':1', ':2', ':3', 1)" $auth_table $arg2 $arg3 $arg4)
-				] [
-					res = -1
-				]
+				add_query = (format "INSERT INTO '%1' (name, pubkey, rights, enabled) VALUES ('%2', '%3', '%4', 1)" $auth_table $arg2 $arg3 $auth_priv)
+				res = (db_query $add_query $auth_db)
 
 				//Tell the player the key was added
 				if (=s $res -1) [
 					db_error $auth_db
 				] [
 					auth_load_from_db
-					pm $arg1 (format "^f6[ AUTHCONTROL ] ^f0A key was successfully added for ^f5%1 ^f0with ^f5%2 ^f0privileges!" $arg2 (? (=s $arg4 "a") "admin" "master"))
+					pm $arg1 (format "^f6[ AUTHCONTROL ] ^f0A key was successfully added for ^f5%1 ^f0with ^f5%2 ^f0privileges!" $arg2 (? (=s $auth_priv "a") "admin" "master"))
 				]
 			]
 		]
 	] [
-		pm $arg1 "^f3[ ERROR ] ^f0You must provide an ^"a^" or an ^"m^" for admin/master privileges!"
+		pm $arg1 "^f3[ ERROR ] ^f0You must provide an ^"a^" or an ^"m^" for admin/master privileges, or leave it blank for the default privilege (master)!"
 	]
 ]
 
 cmd_authstate = [
-	//Check if user exists
-	db__uid = (db_get_dbuid $auth_db)
-
 	tempstring = (format "SELECT rights FROM %1 WHERE name='%2'" $auth_table $arg2)
 	authquery = (db_query $tempstring $auth_db)
 	if (= $authquery -1) [
@@ -58,17 +47,20 @@ cmd_authstate = [
 
 		if (=s $authrow "") [
 			pm $arg1 (format "^f3[ ERROR ] ^f0No one has an authkey with the name ^f5%1" $arg2)
-		] [  //If user exists, validate the integer
-			cond (= $arg3 -1) [  //Delete the authkey
-				cases (db_get_engine $auth_db) "sqlite3" [
-					sqlite3_query $db__uid "BEGIN TRANSACTION"
-					sqlite3_pquery $db__uid "DELETE FROM `:0` WHERE name=':1'" $auth_table $arg2
-					res = (sqlite3_query $db__uid "COMMIT")
-				] "mysql" [
-					res = (mysql_pquery $db__uid "DELETE FROM `:0` WHERE name=':1'" $auth_table $arg2)
-				] [
-					res = -1
-				]
+		] [
+			// If $arg3 not present, toggle enable/disable
+			if (=s $arg3 "") [
+				querystring = (format "SELECT enabled FROM %1 WHERE name='%2'" $auth_table $arg2)
+				query = (db_query $querystring $auth_db)
+				oldstate = (db_getrow $query $auth_db)
+				if (=s (at $oldstate 0) "0") [ new_state = 1 ] [ new_state = 0 ]
+			] [
+				new_state = $arg3
+			]
+
+			cond (= $new_state -1) [  //Delete the authkey
+				query = (format "DELETE FROM '%1' WHERE name='%2'" $auth_table $arg2)
+				res = (db_query $query $auth_db)
 
 				//Send a message to the user if successful then reload keys
 				if (= $res -1) [
@@ -76,25 +68,18 @@ cmd_authstate = [
 				] [
 					pm $arg1 (format "^f6[ AUTHCONTROL ] ^f0The authkey for ^f5%1 ^f0was successfully deleted!" $arg2)
 				]
-			] (|| (= $arg3 1) (! $arg3)) [ //Enables/Disables the authkey
-				cases (db_get_engine $auth_db) "sqlite3" [
-					sqlite3_query $db__uid "BEGIN TRANSACTION"
-					sqlite3_pquery $db__uid "UPDATE `:0` SET enabled=:1 WHERE name=':2'" $auth_table $arg3 $arg2
-					res = (sqlite3_query $db__uid "COMMIT")
-				] "mysql" [
-					res = (mysql_pquery $db__uid "UPDATE `:0` SET enabled=:1 WHERE name=':2'" $auth_table $arg3 $arg2)
-				] [
-					res = -1
-				]
+			] (|| (= $new_state 1) (! $new_state)) [ //Enables/Disables the authkey
+				query = (format "UPDATE '%1' SET enabled=%2 WHERE name='%3'" $auth_table $new_state $arg2)
+				res = (db_query $query $auth_db)
 
 				//Send a message to the user if successful then reload keys
 				if (= $res -1) [
 					db_error $auth_db
 				] [
-					pm $arg1 (format "^f6[ AUTHCONTROL ] ^f0The authkey for ^f5%1 ^f0is now %2" $arg2 (? ($arg3) "enabled" "^f3disabled"))
+					pm $arg1 (format "^f6[ AUTHCONTROL ] ^f0The authkey for ^f5%1 ^f0is now %2" $arg2 (? ($new_state) "enabled" "^f3disabled"))
 				]
 			] [
-				pm $arg1 "^f3[ ERROR ] ^f0You must choose -1, 0, or 1 to change state of this authkey!"
+				pm $arg1 "^f3[ ERROR ] ^f0You must choose -1, 0, or 1 to change state of this authkey!  Leave the state blank to toggle enable/disable!"
 			]
 		]
 	]
@@ -102,10 +87,9 @@ cmd_authstate = [
 
 cmd_authpriv = [
 	//Check if user exists
-	db__uid = (db_get_dbuid $auth_db)
-
 	tempstring = (format "SELECT rights FROM %1 WHERE name='%2'" $auth_table $arg2)
 	authquery = (db_query $tempstring $auth_db)
+
 	if (= $authquery -1) [
 		db_error $auth_db
 	] [
@@ -118,15 +102,8 @@ cmd_authpriv = [
 			if (&& (!=s $arg3 "m") (!=s $arg3 "a")) [ //Validate the privilege
 				pm $arg1 "^f3[ ERROR ] ^f0You must specify ^"a^" or ^"m^" for the privilege!"
 			] [
-				cases (db_get_engine $auth_db) "sqlite3" [
-					sqlite3_query $db__uid "BEGIN TRANSACTION"
-					sqlite3_pquery $db__uid "UPDATE `:0` SET rights=':1' WHERE name=':2'" $auth_table $arg3 $arg2
-					res = (sqlite3_query $db__uid "COMMIT")
-				] "mysql" [
-					res = (mysql_pquery $db__uid "UPDATE `:0` SET rights=':1' WHERE name=':2'" $auth_table $arg3 $arg2)
-				] [
-					res = -1
-				]
+				query = (format "UPDATE '%1' SET rights='%2' WHERE name='%3'" $auth_table $arg3 $arg2)
+				res = (db_query $query $auth_db)
 
 				if (= $res -1) [
 					db_error $auth_db
@@ -165,10 +142,10 @@ cmd_listauth = [
 
 //Register commands
 if (=s $auth_db "") [
-	log_warn "[ AUTHCONTROL ] Commands disabled!  You must use a MySQL/MySQLi database in order to use this script!"
+	log_warn "[ AUTHCONTROL ] Commands disabled!  You must use a MySQL/SQLite database in order to use this script!"
 ] [
-	registercommand "addauth" cmd_addauth 3 "www" "addauth [NAME] [PUBLIC KEY] [A or M] | Adds an authkey with the given information.  Requires an SQLite or MySQL database."
-	registercommand "authstate" cmd_authstate 3 "wi" "authstate [NAME] [-1|0|1] | Changes the state of an authkey.  -1 = delete, 0 = disable, 1 = enable.  NOTE: You must run ^f5#syncauth ^f0after using this command!"
+	registercommand "addauth" cmd_addauth 3 "ww|w" "addauth [NAME] [PUBLIC KEY] (a\m - Default: m) | Adds an authkey with the given information."
+	registercommand "authstate" cmd_authstate 3 "w|i" "authstate [NAME] (-1|0|1 - If blank, toggles the key) | Changes the state of an authkey.  -1 = delete, 0 = disable, 1 = enable.  NOTE: You must run ^f5#syncauth ^f0after using this command!"
 	registercommand "authpriv" cmd_authpriv 3 "ww" "authpriv [NAME] [a|m] | Changes the privileges for a user's authkey between master or admin."
 	registercommand "listauth" cmd_listauth 3 "" "listauth | Lists all users with an authkey.  Green names are masters, orange names are admins."
 ]


### PR DESCRIPTION
Adds commands to control authkeys in-game. It requires the use of an SQL database for the authkeys. Syncauth must be used after the commands.

Commands:
--

addauth [NAME] [PUBLIC KEY] [A or M] - Adds a created authkey to the database with the given information. A/M are Admin/Master respectively.

authstate [NAME] [-1/0/1] - Modifies the state of an authkey with the given name.
- "-1" deletes the key.
- "0" enables the key.
- "1" disables the key.

authpriv [NAME] [a/m] - Changes the privileges of an authkey with the given name. A/m are admin/master respectively.

listauth - Lists all users with authkeys in the database. The names are green and orange for masters and admins.